### PR TITLE
Add support for installing pip and Ansible from init script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+.PHONY : all help setup ansiblify
+
+all:
+	@echo "Hello, nothing to do by default"
+	@echo "Try 'make help'"
+
+# target: help - Display callable targets.
+help:
+	@egrep "^# target:" [Mm]akefile
+
+# target: setup - Run the initial setup script before we can run Ansible
+setup:
+	./initial_setup.sh
+
+# target: provision-stage - Actually provision stage instances through Ansible Tower.
+ansiblify:
+	ansible-playbook ansiblify.yml --connection=local

--- a/ansiblify.yml
+++ b/ansiblify.yml
@@ -1,0 +1,3 @@
+---
+- name: Ansiblify your develeopment environment!
+  hosts: localhost

--- a/ansiblify.yml
+++ b/ansiblify.yml
@@ -1,3 +1,3 @@
 ---
-- name: Ansiblify your develeopment environment!
+- name: Ansiblify your development environment!
   hosts: localhost

--- a/initial_setup.sh
+++ b/initial_setup.sh
@@ -5,4 +5,30 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-printf "\e[34mInstalling stuff!\e[0m\n"
+printf "\e[30;42mInstalling pip!\e[0m\n"
+printf "\e[30;42mThis install follows the official install guide from https://pip.pypa.io/en/stable/installing/\e[0m\n\n"
+
+printf "\e[30;42mFetching official pip bootstrap script\e[0m\n"
+wget https://bootstrap.pypa.io/get-pip.py
+printf '\e[30;42mDone\e[0m\n\n'
+
+printf "\e[30;42mRun pip bootstrap script\e[0m\n"
+sudo -H python get-pip.py
+printf '\e[30;42mDone\e[0m\n\n'
+
+printf "\e[30;42mpip version information\e[0m\n"
+pip --version
+printf '\e[30;42mDone\e[0m\n\n'
+
+printf "\e[30;42mRemove downloaded pip script\e[0m\n"
+rm get-pip.py
+printf '\e[30;42mDone\e[0m\n\n'
+
+printf "\e[30;42mInstalling latest Ansible via pip!\e[0m\n"
+sudo -H pip install ansible
+printf '\e[30;42mDone\e[0m\n\n'
+
+printf "\e[30;42mAnsible version information\e[0m\n"
+ansible --version
+printf '\e[30;42mDone\e[0m\n\n'
+

--- a/initial_setup.sh
+++ b/initial_setup.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+#
+# Run the necessary setup that is needed before Ansible can be used.
+set -o errexit
+set -o pipefail
+set -o nounset
+
+printf "\e[34mInstalling stuff!\e[0m\n"


### PR DESCRIPTION
First iteration of the setup script that will be run before the
Ansible playbooks(s).

`make setup` should now install `pip`, and the latest `Ansible`
