### PR TITLE
Ansiblify editor role

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Local overrides
+group_vars/ansiblify/local.yml

--- a/Makefile
+++ b/Makefile
@@ -14,4 +14,4 @@ setup:
 
 # target: provision-stage - Actually provision stage instances through Ansible Tower.
 ansiblify:
-	ansible-playbook ansiblify.yml --connection=local
+	ansible-playbook -i ansiblify-hosts ansiblify.yml --connection=local --ask-become-pass

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,6 @@ help:
 setup:
 	./initial_setup.sh
 
-# target: provision-stage - Actually provision stage instances through Ansible Tower.
+# target: ansiblify - Run the Ansible playbook to set up your environment
 ansiblify:
 	ansible-playbook -i ansiblify-hosts ansiblify.yml --connection=local --ask-become-pass

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ansiblify
 
-This is an opiniated attempt to make it as easy as possible to set up
-my development environment when setting up a new workstation.
+This is an opinionated attempt to make it as easy as possible to set
+up my development environment when setting up a new workstation.
 Currently this should support Debian and Ubuntu based distros, and is
 now used setting up a Linux Mint environment.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,53 @@
 # ansiblify
 
-This is an attempt to make it as easy as possible to set up my
-development environment when setting up a new workstation. Currently
-this should support Debian and Ubuntu based distros, and is now used
-setting up a Linux Mint environment.
+This is an opiniated attempt to make it as easy as possible to set up
+my development environment when setting up a new workstation.
+Currently this should support Debian and Ubuntu based distros, and is
+now used setting up a Linux Mint environment.
 
-More to come.
+## Setup
+
+There is a `Makefile` included for convenience that has targets to do
+initial setup as well as `Ansiblifying` your environment.
+
+### make setup
+
+Run this to install the latest `pip` and `Ansible`, as well as
+creating a `group_vars/ansiblify/local.yml` for local overrides (more
+on that below).
+
+### make ansiblify
+
+Run this to run the `ansiblify.yml` playbook using all the defaults (
+given you haven't overridden anything in your `local.yml`)
+
+## Local overrides
+
+After running `make setup` you will have a `local.yml` for your local
+overrides when running `make ansiblify`. Just add whatever overrides
+you want within this file as they will be loaded automatically. This
+file is not under version control. All important overrides are
+documented within their roles and in this README.
+
+See the `local.yml` override section per role as well as role READMEs
+for more information about your choices.
+
+## Roles
+
+### editor
+
+Role for installing and configuring your favorite editor.
+
+#### Supported
+
+* [Sublime Text 3](http://www.sublimetext.com/3)
+
+#### local.yml important overrides
+
+See role README for specifics and more defaults.
+
+| Overrides               | Default   | Level |
+|-------------------------|-----------|-------|
+| editor_install          | true      | role  |
+| editor_install_sublime  | true      | task  |
+| editor_sublime_conf_dir | undefined | task  |

--- a/ansiblify-hosts
+++ b/ansiblify-hosts
@@ -1,0 +1,2 @@
+[ansiblify]
+localhost

--- a/ansiblify.yml
+++ b/ansiblify.yml
@@ -1,3 +1,7 @@
 ---
 - name: Ansiblify your development environment!
-  hosts: localhost
+  hosts: ansiblify
+
+  roles:
+    - { name: editor, when: editor_install }
+

--- a/group_vars/ansiblify/main.yml
+++ b/group_vars/ansiblify/main.yml
@@ -1,0 +1,2 @@
+---
+user_home_conf_dir: "~/.config/" 

--- a/initial_setup.sh
+++ b/initial_setup.sh
@@ -32,3 +32,6 @@ printf "\e[30;42mAnsible version information\e[0m\n"
 ansible --version
 printf '\e[30;42mDone\e[0m\n\n'
 
+printf "\e[30;42mCreate local.yml if it doesn't exist\e[0m\n"
+touch group_vars/ansiblify/local.yml
+printf '\e[30;42mDone\e[0m\n\n'

--- a/roles/editor/README.md
+++ b/roles/editor/README.md
@@ -1,0 +1,52 @@
+# ansiblify editor
+
+This role will currently set up Sublime Text 3
+
+## Role variables
+
+### Defaults
+
+The default is to run the editor role, but this can be overridden
+
+    editor_install: true
+
+Each editor will have its own override to be included or not
+
+    editor_install_sublime: true
+
+Sublime Text 3 build to install
+
+    editor_sublime_build: "3083"
+
+Location of the user home `.config` directory. This is used if you
+want to copy existing configuration from a backup location to your
+local `.config` directory.
+
+    user_home_conf_dir: "~/.config/"
+
+### Vars
+
+Checks your architecture before choosing the Sublime package
+
+    editor_sublime_arch:
+      "{% if ansible_architecture == 'x86_64' %}amd64{% else %}i386{% endif %}"
+
+The URL to fetch the Sublime deb package from
+
+    editor_sublime_url:
+      "https://download.sublimetext.com/sublime-text_build-{{ editor_sublime_build }}_{{ editor_sublime_arch }}.deb"
+
+Temporary location for the downloaded file
+
+    editor_sublime_tmp:
+      "/tmp/sublime-text_build-{{ editor_sublime_build }}_{{ editor_sublime_arch }}.deb"
+
+## Dependencies
+
+None
+
+## Example playbook
+
+    - hosts: hosts
+      roles:
+         - { name: editor, when: editor_install }

--- a/roles/editor/defaults/main.yml
+++ b/roles/editor/defaults/main.yml
@@ -7,3 +7,6 @@ editor_install_sublime: true
 
 # Sublime
 editor_sublime_build: "3083"
+
+# User home config directory
+user_home_conf_dir: "~/.config/"

--- a/roles/editor/defaults/main.yml
+++ b/roles/editor/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+# Set this to false when you don't want to install any editors
+editor_install: true
+
+# What editor(s) to install
+editor_install_sublime: true
+
+# Sublime
+editor_sublime_build: "3083"

--- a/roles/editor/tasks/main.yml
+++ b/roles/editor/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- include: sublime.yml
+  when: editor_install_sublime
+

--- a/roles/editor/tasks/sublime.yml
+++ b/roles/editor/tasks/sublime.yml
@@ -1,0 +1,27 @@
+---
+- name: "Ensure chosen build of Sublime Text 3 is downloaded"
+  get_url:
+    url:  "{{ editor_sublime_url }}"
+    dest: "{{ editor_sublime_tmp }}"
+  tags:
+    - editor
+    - sublime
+
+- name: "Ensure Sublime Text 3 is installed"
+  become: yes
+  apt:
+    deb: "{{ editor_sublime_tmp }}"
+  tags:
+    - editor
+    - sublime
+
+- name: "Ensure sublime-text-3 .config changes are copied if applicable"
+  copy:
+    src:  "{{ editor_sublime_conf_dir }}"
+    dest: "{{ user_home_conf_dir }}"
+  when: editor_sublime_conf_dir is defined
+  tags:
+    - editor
+    - sublime
+    - config
+

--- a/roles/editor/vars/main.yml
+++ b/roles/editor/vars/main.yml
@@ -1,5 +1,8 @@
 ---
 # Sublime
-editor_sublime_arch: "{% if ansible_architecture == 'x86_64' %}amd64{% else %}i386{% endif %}"
-editor_sublime_url:  "https://download.sublimetext.com/sublime-text_build-{{ editor_sublime_build }}_{{ editor_sublime_arch }}.deb"
-editor_sublime_tmp:  "/tmp/sublime-text_build-{{ editor_sublime_build }}_{{ editor_sublime_arch }}.deb"
+editor_sublime_arch:
+  "{% if ansible_architecture == 'x86_64' %}amd64{% else %}i386{% endif %}"
+editor_sublime_url:
+  "https://download.sublimetext.com/sublime-text_build-{{ editor_sublime_build }}_{{ editor_sublime_arch }}.deb"
+editor_sublime_tmp:
+  "/tmp/sublime-text_build-{{ editor_sublime_build }}_{{ editor_sublime_arch }}.deb"

--- a/roles/editor/vars/main.yml
+++ b/roles/editor/vars/main.yml
@@ -1,0 +1,5 @@
+---
+# Sublime
+editor_sublime_arch: "{% if ansible_architecture == 'x86_64' %}amd64{% else %}i386{% endif %}"
+editor_sublime_url:  "https://download.sublimetext.com/sublime-text_build-{{ editor_sublime_build }}_{{ editor_sublime_arch }}.deb"
+editor_sublime_tmp:  "/tmp/sublime-text_build-{{ editor_sublime_build }}_{{ editor_sublime_arch }}.deb"


### PR DESCRIPTION
This will add editor support to ansiblify. Currently it only supports Sublime Text 3, but it should be easy to support other editors as well. The only way to currently configure Sublime is to have an existing backup of your .config/sublime-text-3 folder that can be copied in.
